### PR TITLE
Bower install error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "react-bootstrap-datetimepicker",
   "version": "0.0.666666",
   "main": [
-    "./dist/react-bootstrap-datetimepicker.min.js",
+    "./dist/react-bootstrap-datetimepicker.min.js"
   ],
   "ignore": []
 }


### PR DESCRIPTION
We can't install with bower currently. There is a syntax error in bower.json.
```
$ bower install quri/react-bootstrap-datetimepicker
bower react-bootstrap-datetimepicker#*       not-cached https://github.com/quri/react-bootstrap-datetimepicker.git#*
bower react-bootstrap-datetimepicker#*          resolve https://github.com/quri/react-bootstrap-datetimepicker.git#*
bower react-bootstrap-datetimepicker#*         download https://github.com/quri/react-bootstrap-datetimepicker/archive/v
0.0.8.tar.gz
bower react-bootstrap-datetimepicker#*          extract archive.tar.gz
bower react-bootstrap-datetimepicker#*       EMALFORMED Failed to read C:\Users\wadahiro\AppData\Local\Temp\wadahiro-PC-wadahiro\bower\react-bootstrap-datetimepicker-7300-v2JVvK\bower.json

Additional error details:
Unexpected token ]
```
