### PR TITLE
Changing anchor tag to span to meet accessibility rules

### DIFF
--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -87,7 +87,7 @@ DateTimePicker = React.createClass({
           {this.renderDatePicker()}
 
           <li>
-            <a className="btn picker-switch" style={{width:'100%'}} onClick={this.props.togglePicker}><Glyphicon glyph={this.props.showTimePicker ? 'calendar' : 'time'} /></a>
+            <span className="btn picker-switch" style={{width:'100%'}} onClick={this.props.togglePicker}><Glyphicon glyph={this.props.showTimePicker ? 'calendar' : 'time'} /></span>
           </li>
 
           {this.renderTimePicker()}


### PR DESCRIPTION
You may have gathered from my other PR #30 that I'm doing some accessibility work on my current project. The current implementation of react-bootstrap-datetimepicker violates two accessibility rules. They are:

- WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.EmptyNoId
- WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent

You can read more than you'd ever care to know about those two here: http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/4_1_2

Anyway, the short version is there is an anchor tag that is not being used as an anchor tag (no href and no text content within the element) which violates accessibility rules. The simple fix to this is to use a span instead.

What do you think?