### PR TITLE
bugfix: prev/next month day selection should not select day from curr…

### DIFF
--- a/src/DateTimeField.jsx
+++ b/src/DateTimeField.jsx
@@ -74,8 +74,18 @@ DateTimeField = React.createClass({
   },
   setSelectedDate: function(e) {
     if (e.target.className && !e.target.className.match(/disabled/g)) {
+      var newDate = this.state.viewDate.clone();
+      newDate = newDate.date("1"); // avoid end of month day count issue due to following date modification
+      if(e.target.className.match(/old/g)){
+        newDate.subtract(1, "month"); // this is a day from the previous month
+      }else if(e.target.className.match(/new/g)){
+        newDate.add(1, "month"); // this is a day from the next month
+      }
+      // update day, hour, minute
+      newDate = newDate.date(parseInt(e.target.innerHTML)).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes());
+
       return this.setState({
-        selectedDate: this.state.viewDate.clone().date(parseInt(e.target.innerHTML)).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
+        selectedDate: newDate
       }, function () {
         this.closePicker();
         this.props.onChange(this.state.selectedDate.format(this.props.format));


### PR DESCRIPTION
…ent month.
-- longer description --
When day picker is open it shows day from from 'current' month but also days from previous month and next month, in gray. When you select these day, it should correctly select a day from the previous or the next month.
To see the bug, try it live:
http://dev.quri.com/react-bootstrap-datetimepicker/
Select a day from the previous month or next month.
Eg. today : 05/10/15 1:35 PM
Open date picker. Select April 30 (in gray)
you get: May 30.
Same apply with day of next month.