### PR TITLE
Fixed daysOfWeekDisabled not working with non-sequential days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-built/*
 docs/*.html
 docs/assets/bundle.js
 lib/*
+/bower_components/

--- a/src/DateTimePickerDays.js
+++ b/src/DateTimePickerDays.js
@@ -56,14 +56,7 @@ export default class DateTimePickerDays extends Component {
       if ((minDate && prevMonth.isBefore(minDate)) || (maxDate && prevMonth.isAfter(maxDate))) {
         classes.disabled = true;
       }
-      if (this.props.daysOfWeekDisabled) {
-        for (let i = 0, len = this.props.daysOfWeekDisabled.length; i < len; i++) {
-          if (prevMonth.day() === this.props.daysOfWeekDisabled[i]) {
-            classes.disabled = true;
-            break;
-          }
-        }
-      }
+      if (this.props.daysOfWeekDisabled) classes.disabled = this.props.daysOfWeekDisabled.indexOf(prevMonth.day()) !== -1;
       cells.push(<td key={prevMonth.month() + "-" + prevMonth.date()} className={classnames(classes)} onClick={this.props.setSelectedDate}>{prevMonth.date()}</td>);
       if (prevMonth.weekday() === moment().endOf("week").weekday()) {
         row = <tr key={prevMonth.month() + "-" + prevMonth.date()}>{cells}</tr>;


### PR DESCRIPTION
Disabling weekends with `daysOfWeekDisabled={[0,6]}` would not work due to the for loop getting confused.

Instead, using a `indexOf` simplifies the loop / break and makes the intention clearer.