### PR TITLE
raw value as additional argument for this.props.onChange

### DIFF
--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -90,7 +90,7 @@ export default class DateTimeField extends Component {
     return this.setState({
       inputValue: value
     }, function() {
-      return this.props.onChange(moment(this.state.inputValue, this.state.inputFormat, true).format(this.props.format));
+      return this.props.onChange(moment(this.state.inputValue, this.state.inputFormat, true).format(this.props.format), value);
     });
 
   }


### PR DESCRIPTION
Added an additional argument to the this.props.onChange callback containing the raw value of the input field.

I have used this to integrate datepicker with Formsy input controls.