### PR TITLE
added length check for this.props.daysOfWeekDisabled

### DIFF
--- a/src/DateTimePickerDays.js
+++ b/src/DateTimePickerDays.js
@@ -56,7 +56,7 @@ export default class DateTimePickerDays extends Component {
       if ((minDate && prevMonth.isBefore(minDate)) || (maxDate && prevMonth.isAfter(maxDate))) {
         classes.disabled = true;
       }
-      if (this.props.daysOfWeekDisabled) classes.disabled = this.props.daysOfWeekDisabled.indexOf(prevMonth.day()) !== -1;
+      if (this.props.daysOfWeekDisabled.length > 0) classes.disabled = this.props.daysOfWeekDisabled.indexOf(prevMonth.day()) !== -1;
       cells.push(<td key={prevMonth.month() + "-" + prevMonth.date()} className={classnames(classes)} onClick={this.props.setSelectedDate}>{prevMonth.date()}</td>);
       if (prevMonth.weekday() === moment().endOf("week").weekday()) {
         row = <tr key={prevMonth.month() + "-" + prevMonth.date()}>{cells}</tr>;


### PR DESCRIPTION
I tried to use the minDate and maxDate props for the react bootstrap datetimepicker, but they never worked and after investigating further I found out that there is an if statement that overrides the disabled dates that were set from the minDate, maxDate if you have used the daysOfWeekDisabled prop.