### PR TITLE
add numeric type support for "dateTime" attribute

### DIFF
--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -30,7 +30,10 @@ export default class DateTimeField extends Component {
   }
 
   static propTypes = {
-    dateTime: PropTypes.string,
+    dateTime: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
     onChange: PropTypes.func,
     format: PropTypes.string,
     inputProps: PropTypes.object,


### PR DESCRIPTION
As far as Unix timestamp is expected for "dateTime" it is clearly that the component should allow numeric values. Otherwise, a warning is generated

    Warning: Failed propType: Invalid prop `dateTime` of type `number` supplied to `DateTimeField`, expected `string`