### PR TITLE
Updated example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install react-bootstrap-datetimepicker
 
 Then
 ```javascript
-require('react-bootstrap-datetimepicker');
+var DateTimeField = require('react-bootstrap-datetimepicker');
 
 ...
 


### PR DESCRIPTION
Updated example so the require('react-bootstrap-datetimepicker') works as expected.