### PR TITLE
Remove React-Bootstrap dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   "dependencies": {
     "babel-runtime": "^5.6.18",
     "classnames": "^2.1.2",
-    "moment": "^2.8.2",
-    "react-bootstrap": "^0.16.1"
+    "moment": "^2.8.2"
   }
 }

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import moment from "moment";
-import { Glyphicon } from "react-bootstrap";
+import classnames from "classnames";
 import DateTimePicker from "./DateTimePicker.js";
 import Constants from "./Constants.js";
 
@@ -54,7 +54,7 @@ export default class DateTimeField extends Component {
       showDatePicker: this.props.mode !== Constants.MODE_TIME,
       showTimePicker: this.props.mode === Constants.MODE_TIME,
       inputFormat: this.resolvePropsInputFormat(),
-      buttonIcon: this.props.mode === Constants.MODE_TIME ? "time" : "calendar",
+      buttonIcon: this.props.mode === Constants.MODE_TIME ? "glyphicon-time" : "glyphicon-calendar",
       widgetStyle: {
         display: "block",
         position: "absolute",
@@ -375,7 +375,7 @@ export default class DateTimeField extends Component {
             <div className={"input-group date " + this.size()} ref="datetimepicker">
               <input className="form-control" onChange={this.onChange} type="text" value={this.state.inputValue} {...this.props.inputProps}/>
               <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
-                <Glyphicon glyph={this.state.buttonIcon} />
+                <span className={classnames("glyphicon", this.state.buttonIcon)} />
               </span>
             </div>
           </div>

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from "react";
-import { Glyphicon } from "react-bootstrap";
 import classnames from "classnames";
 import DateTimePickerDate from "./DateTimePickerDate.js";
 import DateTimePickerTime from "./DateTimePickerTime.js";
@@ -93,7 +92,7 @@ export default class DateTimePicker extends Component {
       return this.props.mode === Constants.MODE_DATETIME ?
           (
               <li>
-                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.togglePicker}><Glyphicon glyph={this.props.showTimePicker ? "calendar" : "time"} /></span>
+                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.togglePicker}><span className={classnames("glyphicon", this.props.showTimePicker ? "glyphicon-calendar" : "glyphicon-time")} /></span>
               </li>
           ) :
           null;

--- a/src/DateTimePickerDays.js
+++ b/src/DateTimePickerDays.js
@@ -74,11 +74,11 @@ export default class DateTimePickerDays extends Component {
         <table className="table-condensed">
           <thead>
             <tr>
-              <th className="prev" onClick={this.props.subtractMonth}>‹</th>
+              <th className="prev" onClick={this.props.subtractMonth}><span className="glyphicon glyphicon-chevron-left" /></th>
 
               <th className="switch" colSpan="5" onClick={this.props.showMonths}>{moment.months()[this.props.viewDate.month()]} {this.props.viewDate.year()}</th>
 
-              <th className="next" onClick={this.props.addMonth}>›</th>
+              <th className="next" onClick={this.props.addMonth}><span className="glyphicon glyphicon-chevron-right" /></th>
             </tr>
 
             <tr>

--- a/src/DateTimePickerHours.js
+++ b/src/DateTimePickerHours.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from "react";
-import { Glyphicon } from "react-bootstrap";
 import Constants from "./Constants.js";
 
 export default class DateTimePickerHours extends Component {
@@ -14,7 +13,7 @@ export default class DateTimePickerHours extends Component {
         (
             <ul className="list-unstyled">
               <li>
-                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.onSwitch}><Glyphicon glyph="time" /></span>
+                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.onSwitch}><span className="glyphicon glyphicon-time" /></span>
               </li>
             </ul>
         ) :

--- a/src/DateTimePickerMinutes.js
+++ b/src/DateTimePickerMinutes.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from "react";
-import { Glyphicon } from "react-bootstrap";
 import Constants from "./Constants.js";
 
 export default class DateTimePickerMinutes extends Component {
@@ -14,7 +13,7 @@ export default class DateTimePickerMinutes extends Component {
         (
             <ul className="list-unstyled">
               <li>
-                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.onSwitch}><Glyphicon glyph="time" /></span>
+                <span className="btn picker-switch" style={{width: "100%"}} onClick={this.props.onSwitch}><span className="glyphicon glyphicon-time" /></span>
               </li>
             </ul>
         ) :

--- a/src/DateTimePickerTime.js
+++ b/src/DateTimePickerTime.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from "react";
-import { Glyphicon } from "react-bootstrap";
 import DateTimePickerMinutes from "./DateTimePickerMinutes";
 import DateTimePickerHours from "./DateTimePickerHours";
 import Constants from "./Constants.js";
@@ -65,11 +64,11 @@ export default class DateTimePickerTime extends Component {
         <table className="table-condensed">
           <tbody>
             <tr>
-              <td><a className="btn" onClick={this.props.addHour}><Glyphicon glyph="chevron-up" /></a></td>
+              <td><a className="btn" onClick={this.props.addHour}><span className="glyphicon glyphicon-chevron-up" /></a></td>
 
               <td className="separator"></td>
 
-              <td><a className="btn" onClick={this.props.addMinute}><Glyphicon glyph="chevron-up" /></a></td>
+              <td><a className="btn" onClick={this.props.addMinute}><span className="glyphicon glyphicon-chevron-up" /></a></td>
 
               <td className="separator"></td>
             </tr>
@@ -87,11 +86,11 @@ export default class DateTimePickerTime extends Component {
             </tr>
 
             <tr>
-              <td><a className="btn" onClick={this.props.subtractHour}><Glyphicon glyph="chevron-down" /></a></td>
+              <td><a className="btn" onClick={this.props.subtractHour}><span className="glyphicon glyphicon-chevron-down" /></a></td>
 
               <td className="separator"></td>
 
-              <td><a className="btn" onClick={this.props.subtractMinute}><Glyphicon glyph="chevron-down" /></a></td>
+              <td><a className="btn" onClick={this.props.subtractMinute}><span className="glyphicon glyphicon-chevron-down" /></a></td>
 
               <td className="separator"></td>
             </tr>


### PR DESCRIPTION
As pointed out by some in #111 , this component does not need a react-bootstrap dependency and could facilitate easier integration in existing projects.