### PR TITLE
Add month picker option to mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ DateTimeField
 | ------------ | ------- | ------- | ----------- |
 | **dateTime** | string  | moment().format('x') | Represents the inital dateTime, this string is then parsed by moment.js |
 | **format**   | string  | "x"     | Defines the format moment.js should use to parse and output the date to onChange |
-| **inputFormat** | string | "MM/DD/YY h:mm A" | Defines the way the date is represented in the HTML input. It must be a format understanable by moment.js |
+| **inputFormat** | string | "MM/DD/YY h:mm A" | Defines the way the date is represented in the HTML input. It must be a format understandable by moment.js |
 | **onChange** | function | x => console.log(x) | Callback trigger when the date changes. `x` is the new datetime value. |
 | **showToday** | boolean | true | Highlights today's date |
 | **size** | string | "md" | Changes the size of the date picker input field. Sizes: "sm", "md", "lg" |
@@ -42,7 +42,7 @@ DateTimeField
 | **inputProps** | object | undefined | Defines additional attributes for the input element of the component. |
 | **minDate** | moment | undefined | The earliest date allowed for entry in the calendar view. |
 | **maxDate** | moment | undefined | The latest date allowed for entry in the calendar view. |
-| **mode** | string | undefined | Allows to selectively display only the time picker ('time') or the date picker ('date') |
+| **mode** | string | undefined | Allows to selectively display only the time picker ('time'), date picker ('date'), or month picker ('month') |
 | **defaultText** | string | {dateTime} | Sets the initial value. Could be an empty string, or helper text. |
 
 Update Warning

--- a/examples/basic/basic.js
+++ b/examples/basic/basic.js
@@ -50,15 +50,15 @@ class Basic extends Component {
                 </pre>
               </div>
             </div>
-              <div className="row">
-                <div className="col-xs-12">
-                  Example with default Text
-                  <DateTimeField
-                    defaultText="Please select a date"
-                  />
-                  <pre> {'<DateTimeField defaultText="Please select a date" />'} </pre>
-                </div>
+            <div className="row">
+              <div className="col-xs-12">
+                Example with default Text
+                <DateTimeField
+                  defaultText="Please select a date"
+                />
+                <pre> {'<DateTimeField defaultText="Please select a date" />'} </pre>
               </div>
+            </div>
             <div className="row">
 							<div className="col-xs-12">
 								Default Basic Example

--- a/examples/basic/basic.js
+++ b/examples/basic/basic.js
@@ -102,26 +102,35 @@ class Basic extends Component {
                   maxDate={moment().add(1, "days")}
                   minDate={moment().subtract(1, "days")}
                 />
-                <pre> {'<DateTimeField daysOfWeekDisabled={[0,1,2]} />'} </pre>
-
+                <pre> {'<DateTimeField maxDate={moment().add(1, "days")}\n' +
+                'minDate={moment().subtract(1, "days")} />'} </pre>
               </div>
 						</div>
             <div className="row">
               <div className="col-xs-12">
-                  just time picker
-                  <DateTimeField
-                      mode="time"
-                      />
-                  <pre> {'<DateTimeField mode="time" />'} </pre>
+                just time picker
+                <DateTimeField
+                  mode="time"
+                />
+                <pre> {'<DateTimeField mode="time" />'} </pre>
               </div>
             </div>
             <div className="row">
               <div className="col-xs-12">
-                  just date picker
-                  <DateTimeField
-                      mode="date"
-                      />
-                  <pre> {'<DateTimeField mode="date" />'} </pre>
+                just date picker
+                <DateTimeField
+                  mode="date"
+                />
+                <pre> {'<DateTimeField mode="date" />'} </pre>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-xs-12">
+                just month picker
+                <DateTimeField
+                  mode="month"
+                />
+                <pre> {'<DateTimeField mode="month" />'} </pre>
               </div>
             </div>
           </div>

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,5 +1,6 @@
 module.exports = {
     MODE_DATE: "date",
+    MODE_MONTH: "month",
     MODE_DATETIME: "datetime",
     MODE_TIME: "time",
 

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -123,7 +123,9 @@ export default class DateTimeField extends Component {
     const { target } = e;
     if (target.className && !target.className.match(/disabled/g)) {
       return this.setState({
-        selectedDate: this.state.viewDate.clone().month(e.target.innerHTML).date(this.state.selectedDate.date()).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
+        selectedDate: moment(this.state.viewDate.clone().toDate())
+          .month(e.target.innerHTML).date(1)
+          .hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
       }, function() {
         this.closePicker();
         this.props.onChange(this.state.selectedDate.format(this.props.format));
@@ -144,7 +146,7 @@ export default class DateTimeField extends Component {
       else if (target.className.indexOf("old") >= 0) month = this.state.viewDate.month() - 1;
       else month = this.state.viewDate.month();
       return this.setState({
-        selectedDate: this.state.viewDate.clone().month(month).date(parseInt(e.target.innerHTML)).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
+        selectedDate: moment(this.state.viewDate.clone().toDate()).month(month).date(parseInt(e.target.innerHTML)).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
       }, function() {
         this.closePicker();
         this.props.onChange(this.state.selectedDate.format(this.props.format));

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -289,6 +289,21 @@ export default class DateTimeField extends Component {
     });
   }
 
+  setToday = () => {
+    var today = moment();
+    this.setIsValid(true);
+    return this.setState({
+      selectedDate: today,
+    }, function() {
+      this.closePicker();
+      this.props.onChange(today);
+      console.log(this.state.selectedDate)
+      return this.setState({
+        inputValue: this.state.selectedDate.format(this.resolvePropsInputFormat())
+      });
+    });
+  }
+
   onClick = () => {
     let classes, gBCR, offset, placePosition, scrollTop, styles, widgetOffsetHeight, clientHeight, height;
     if (this.state.showPicker) {
@@ -397,6 +412,7 @@ export default class DateTimeField extends Component {
                   setSelectedMinute={this.setSelectedMinute}
                   setViewMonth={this.setViewMonth}
                   setViewYear={this.setViewYear}
+                  setToday={this.setToday}
                   showDatePicker={this.state.showDatePicker}
                   showTimePicker={this.state.showTimePicker}
                   showToday={this.props.showToday}

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -136,7 +136,6 @@ export default class DateTimeField extends Component {
 
   setSelectedDate = (e) => {
     const { target } = e;
-    const value = target == null ? event : event.target.value;
 
     if (target.className && !target.className.match(/disabled/g)) {
       this.setIsValid(true);

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -25,6 +25,8 @@ export default class DateTimeField extends Component {
         return "h:mm A";
       case Constants.MODE_DATE:
         return "MM/DD/YY";
+      case Constants.MODE_MONTH:
+        return "MM/YY";
       default:
         return "MM/DD/YY h:mm A";
     }
@@ -40,7 +42,7 @@ export default class DateTimeField extends Component {
     inputProps: PropTypes.object,
     inputFormat: PropTypes.string,
     defaultText: PropTypes.string,
-    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_DATETIME, Constants.MODE_TIME]),
+    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_MONTH, Constants.MODE_DATETIME, Constants.MODE_TIME]),
     minDate: PropTypes.object,
     maxDate: PropTypes.object,
     direction: PropTypes.string,
@@ -102,6 +104,21 @@ export default class DateTimeField extends Component {
 
   getValue = () => {
     return moment(this.state.inputValue, this.props.inputFormat, true).format(this.props.format);
+  }
+
+  setSelectedMonth = (e) => {
+    const { target } = e;
+    if (target.className && !target.className.match(/disabled/g)) {
+      return this.setState({
+        selectedDate: this.state.viewDate.clone().month(e.target.innerHTML).date(this.state.selectedDate.date()).hour(this.state.selectedDate.hours()).minute(this.state.selectedDate.minutes())
+      }, function() {
+        this.closePicker();
+        this.props.onChange(this.state.selectedDate.format(this.props.format));
+        return this.setState({
+          inputValue: this.state.selectedDate.format(this.state.inputFormat)
+        });
+      });
+    }
   }
 
   setSelectedDate = (e) => {
@@ -352,6 +369,7 @@ export default class DateTimeField extends Component {
                   mode={this.props.mode}
                   ref="widget"
                   selectedDate={this.state.selectedDate}
+                  setSelectedMonth={this.setSelectedMonth}
                   setSelectedDate={this.setSelectedDate}
                   setSelectedHour={this.setSelectedHour}
                   setSelectedMinute={this.setSelectedMinute}

--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -67,7 +67,7 @@ export default class DateTimeField extends Component {
       },
       viewDate: moment(this.props.dateTime, this.props.format, true).startOf("month"),
       selectedDate: moment(this.props.dateTime, this.props.format, true),
-      inputValue: typeof this.props.defaultText !== "undefined" ? this.props.defaultText : moment(this.props.dateTime, this.props.format, true).format(this.resolvePropsInputFormat()),
+      inputValue: typeof this.props.defaultText !== "undefined" ? undefined : moment(this.props.dateTime, this.props.format, true).format(this.resolvePropsInputFormat()),
       isValid: true
   }
 
@@ -413,7 +413,7 @@ export default class DateTimeField extends Component {
                   widgetStyle={this.state.widgetStyle}
             />
             <div className={classnames("input-group date " + this.size(), {"has-error": !this.state.isValid})} ref="datetimepicker">
-              <input className="form-control" onChange={this.onChange} type="text" value={this.state.inputValue} {...this.props.inputProps} ref="inputDateTime"/>
+              <input className="form-control" onChange={this.onChange} type="text" value={this.state.inputValue} {...this.props.inputProps} ref="inputDateTime" placeholder={this.props.defaultText}/>
               <span className="input-group-addon" onBlur={this.onBlur} onClick={this.onClick} ref="dtpbutton">
                 <span className={classnames("glyphicon", this.state.buttonIcon)} />
               </span>

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -38,7 +38,8 @@ export default class DateTimePicker extends Component {
     widgetStyle: PropTypes.object,
     togglePicker: PropTypes.func,
     setSelectedHour: PropTypes.func,
-    setSelectedMinute: PropTypes.func
+    setSelectedMinute: PropTypes.func,
+    setToday: PropTypes.func
   }
 
   renderDatePicker = () => {
@@ -96,6 +97,12 @@ export default class DateTimePicker extends Component {
           (
               <li>
                 <span className="btn picker-switch" onClick={this.props.togglePicker} style={{width: "100%"}} ><span className={classnames("glyphicon", this.props.showTimePicker ? "glyphicon-calendar" : "glyphicon-time")} /></span>
+              </li>
+          ) :
+          this.props.mode === Constants.MODE_DATE ?
+          (
+              <li>
+                <span className="btn btn-today" onClick={this.props.setToday} style={{width: "100%"}}>Today</span>
               </li>
           ) :
           null;

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -103,7 +103,7 @@ export default class DateTimePicker extends Component {
 
   render() {
     return (
-      <div className={classnames(this.props.widgetClasses)} style={this.props.widgetStyle}>
+      <div className={classnames('bootstrap-datetimepicker-widget', 'dropdown-menu', this.props.widgetClasses)} style={this.props.widgetStyle}>
 
         <ul className="list-unstyled">
 
@@ -120,4 +120,3 @@ export default class DateTimePicker extends Component {
     );
   }
 }
-

--- a/src/DateTimePicker.js
+++ b/src/DateTimePicker.js
@@ -17,8 +17,9 @@ export default class DateTimePicker extends Component {
       PropTypes.string,
       PropTypes.number
     ]),
-    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_DATETIME, Constants.MODE_TIME]),
+    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_MONTH, Constants.MODE_DATETIME, Constants.MODE_TIME]),
     daysOfWeekDisabled: PropTypes.array,
+    setSelectedMonth: PropTypes.func.isRequired,
     setSelectedDate: PropTypes.func.isRequired,
     subtractYear: PropTypes.func.isRequired,
     addYear: PropTypes.func.isRequired,
@@ -52,6 +53,7 @@ export default class DateTimePicker extends Component {
               maxDate={this.props.maxDate}
               minDate={this.props.minDate}
               selectedDate={this.props.selectedDate}
+              setSelectedMonth={this.props.setSelectedMonth}
               setSelectedDate={this.props.setSelectedDate}
               setViewMonth={this.props.setViewMonth}
               setViewYear={this.props.setViewYear}
@@ -61,6 +63,7 @@ export default class DateTimePicker extends Component {
               subtractYear={this.props.subtractYear}
               viewDate={this.props.viewDate}
               viewMode={this.props.viewMode}
+              mode={this.props.mode}
         />
       </li>
       );

--- a/src/DateTimePickerDate.js
+++ b/src/DateTimePickerDate.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 import DateTimePickerDays from "./DateTimePickerDays";
 import DateTimePickerMonths from "./DateTimePickerMonths";
 import DateTimePickerYears from "./DateTimePickerYears";
+import Constants from "./Constants.js";
 
 export default class DateTimePickerDate extends Component {
   static propTypes = {
@@ -14,7 +15,9 @@ export default class DateTimePickerDate extends Component {
       PropTypes.string,
       PropTypes.number
     ]),
+    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_MONTH, Constants.MODE_DATETIME]),
     daysOfWeekDisabled: PropTypes.array,
+    setSelectedMonth: PropTypes.func.isRequired,
     setSelectedDate: PropTypes.func.isRequired,
     subtractYear: PropTypes.func.isRequired,
     addYear: PropTypes.func.isRequired,
@@ -46,6 +49,9 @@ export default class DateTimePickerDate extends Component {
       }
     };
     this.state = viewModes[this.props.viewMode] || viewModes[Object.keys(viewModes)[this.props.viewMode]] || viewModes.days;
+    if (this.state.daysDisplayed && this.props.mode === Constants.MODE_MONTH) {
+      this.state = viewModes.months;
+    }
   }
 
   showMonths = () => {
@@ -105,10 +111,12 @@ export default class DateTimePickerDate extends Component {
       <DateTimePickerMonths
             addYear={this.props.addYear}
             selectedDate={this.props.selectedDate}
+            setSelectedMonth={this.props.setSelectedMonth}
             setViewMonth={this.setViewMonth}
             showYears={this.showYears}
             subtractYear={this.props.subtractYear}
             viewDate={this.props.viewDate}
+            mode={this.props.mode}
       />
       );
     } else {

--- a/src/DateTimePickerMonths.js
+++ b/src/DateTimePickerMonths.js
@@ -39,11 +39,11 @@ export default class DateTimePickerMonths extends Component {
           <table className="table-condensed">
             <thead>
               <tr>
-                <th className="prev" onClick={this.props.subtractYear}>‹</th>
+                <th className="prev" onClick={this.props.subtractYear}><span className="glyphicon glyphicon-chevron-left" /></th>
 
                 <th className="switch" colSpan="5" onClick={this.props.showYears}>{this.props.viewDate.year()}</th>
 
-                <th className="next" onClick={this.props.addYear}>›</th>
+                <th className="next" onClick={this.props.addYear}><span className="glyphicon glyphicon-chevron-right" /></th>
               </tr>
             </thead>
 
@@ -57,4 +57,3 @@ export default class DateTimePickerMonths extends Component {
     );
   }
 }
-

--- a/src/DateTimePickerMonths.js
+++ b/src/DateTimePickerMonths.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import classnames from "classnames";
 import moment from "moment";
+import Constants from "./Constants.js";
 
 export default class DateTimePickerMonths extends Component {
   static propTypes = {
@@ -9,11 +10,14 @@ export default class DateTimePickerMonths extends Component {
     viewDate: PropTypes.object.isRequired,
     selectedDate: PropTypes.object.isRequired,
     showYears: PropTypes.func.isRequired,
-    setViewMonth: PropTypes.func.isRequired
+    setViewMonth: PropTypes.func.isRequired,
+    setSelectedMonth: PropTypes.func.isRequired,
+    mode: PropTypes.oneOf([Constants.MODE_DATE, Constants.MODE_MONTH, Constants.MODE_DATETIME])
   }
 
   renderMonths = () => {
     var classes, i, month, months, monthsShort;
+    const onClick = this.props.mode === Constants.MODE_MONTH ? this.props.setSelectedMonth : this.props.setViewMonth;
     month = this.props.selectedDate.month();
     monthsShort = moment.monthsShort();
     i = 0;
@@ -23,7 +27,7 @@ export default class DateTimePickerMonths extends Component {
         month: true,
         "active": i === month && this.props.viewDate.year() === this.props.selectedDate.year()
       };
-      months.push(<span className={classnames(classes)} key={i} onClick={this.props.setViewMonth}>{monthsShort[i]}</span>);
+      months.push(<span className={classnames(classes)} key={i} onClick={onClick}>{monthsShort[i]}</span>);
       i++;
     }
     return months;

--- a/src/DateTimePickerYears.js
+++ b/src/DateTimePickerYears.js
@@ -37,11 +37,11 @@ export default class DateTimePickerYears extends Component {
         <table className="table-condensed">
           <thead>
             <tr>
-              <th className="prev" onClick={this.props.subtractDecade}>‹</th>
+              <th className="prev" onClick={this.props.subtractDecade}><span className="glyphicon glyphicon-chevron-left" /></th>
 
               <th className="switch" colSpan="5">{year} - {year + 9}</th>
 
-              <th className="next" onClick={this.props.addDecade}>›</th>
+              <th className="next" onClick={this.props.addDecade}><span className="glyphicon glyphicon-chevron-right" /></th>
             </tr>
           </thead>
 
@@ -55,4 +55,3 @@ export default class DateTimePickerYears extends Component {
     );
   }
 }
-

--- a/src/__tests__/DateTimeField-test.js
+++ b/src/__tests__/DateTimeField-test.js
@@ -58,9 +58,9 @@ describe("DateTimeField", function() {
     it("doesn't change the defaultText if dateTime didn't change", function() {
       const Parent = createParent({defaultText: "Pick a date"});
       const input = TestUtils.findRenderedDOMComponentWithTag(Parent, "input");
-      expect(input.value).toBe("Pick a date");
+      expect(input.getAttribute('placeholder')).toBe("Pick a date");
       Parent.setState({});
-      expect(input.value).toBe("Pick a date");
+      expect(input.getAttribute('placeholder')).toBe("Pick a date");
     });
 
 

--- a/src/__tests__/DateTimePickerDate-test.js
+++ b/src/__tests__/DateTimePickerDate-test.js
@@ -1,0 +1,104 @@
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+
+jest.dontMock("moment");
+jest.dontMock("../DateTimePickerDate.js");
+
+describe("DateTimePickerDate", function() {
+  const moment = require("moment");
+  const DateTimePickerDate = require("../DateTimePickerDate.js");
+
+  let subtractMonthMock, addMonthMock, viewDate, selectedDate, setSelectedMonthMock, setSelectedDateMock,
+    subtractYearMock, addYearMock, setViewMonthMock, setViewYearMock, addDecadeMock, subtractDecadeMock;
+
+
+  beforeEach(() => {
+    subtractMonthMock = jest.genMockFunction();
+    addMonthMock = jest.genMockFunction();
+    viewDate = moment();
+    selectedDate = moment();
+    setSelectedMonthMock = jest.genMockFunction();
+    setSelectedDateMock = jest.genMockFunction();
+    subtractYearMock = jest.genMockFunction();
+    addYearMock = jest.genMockFunction();
+    setViewMonthMock = jest.genMockFunction();
+    setViewYearMock = jest.genMockFunction();
+    addDecadeMock = jest.genMockFunction();
+    subtractDecadeMock = jest.genMockFunction();
+  })
+
+  function render(args) {
+    let {viewMode, mode} = args;
+    return TestUtils.renderIntoDocument(<DateTimePickerDate
+      subtractMonth={subtractMonthMock}
+      addMonth={addMonthMock}
+      viewDate={viewDate}
+      selectedDate={selectedDate}
+      viewMode={viewMode}
+      mode={mode}
+      setSelectedMonth={setSelectedMonthMock}
+      setSelectedDate={setSelectedDateMock}
+      subtractYear={subtractYearMock}
+      addYear={addYearMock}
+      setViewMonth={setViewMonthMock}
+      setViewYear={setViewYearMock}
+      addDecade={addDecadeMock}
+      subtractDecade={subtractDecadeMock}
+    />)
+  }
+
+  describe("initial state", function() {
+    describe("when it is a regular date picker", function() {
+      it("shows days by default", function() {
+        let picker = render({});
+
+        expect(picker.state.daysDisplayed).toBe(true);
+      })
+
+      it("shows days when that is the view mode", function() {
+        let picker = render({viewMode: "days"});
+
+        expect(picker.state.daysDisplayed).toBe(true);
+      })
+
+      it("shows months when that is the view mode", function() {
+        let picker = render({viewMode: "months"});
+
+        expect(picker.state.monthsDisplayed).toBe(true);
+      })
+
+      it("shows years when that is the view mode", function() {
+        let picker = render({viewMode: "years"});
+
+        expect(picker.state.yearsDisplayed).toBe(true);
+      })
+    })
+
+    describe("when it is a month picker", function() {
+      it("shows months by default", function() {
+        let picker = render({mode: "month"});
+
+        expect(picker.state.monthsDisplayed).toBe(true);
+      })
+
+      it("shows months when the view mode is explicitly days", function() {
+        let picker = render({viewMode: "days", mode: "month"});
+
+        expect(picker.state.monthsDisplayed).toBe(true);
+      })
+
+      it("shows months when that is the view mode", function() {
+        let picker = render({viewMode: "months", mode: "month"});
+
+        expect(picker.state.monthsDisplayed).toBe(true);
+      })
+
+      it("shows years when that is the view mode", function() {
+        let picker = render({viewMode: "years", mode: "month"});
+
+        expect(picker.state.yearsDisplayed).toBe(true);
+      })
+    })
+  });
+
+});

--- a/src/__tests__/DateTimePickerMonths-test.js
+++ b/src/__tests__/DateTimePickerMonths-test.js
@@ -7,13 +7,14 @@ jest.dontMock("../DateTimePickerMonths.js");
 describe("DateTimePickerMonths", function() {
   const moment = require("moment");
   const DateTimePickerMonths = require("../DateTimePickerMonths.js");
-  let subtractYearMock, addYearMock, setViewMonthMock, showYearsMock, months;
+  let subtractYearMock, addYearMock, setViewMonthMock, setSelectedMonthMock, showYearsMock, months;
 
   beforeEach(() => {
     subtractYearMock = jest.genMockFunction();
     addYearMock = jest.genMockFunction();
     showYearsMock = jest.genMockFunction();
     setViewMonthMock = jest.genMockFunction();
+    setSelectedMonthMock = jest.genMockFunction();
     months = TestUtils.renderIntoDocument(
       <DateTimePickerMonths
         addYear={addYearMock}
@@ -22,6 +23,8 @@ describe("DateTimePickerMonths", function() {
         showYears={showYearsMock}
         subtractYear={subtractYearMock}
         viewDate={moment()}
+        setSelectedMonth={setSelectedMonthMock}
+        mode={"date"}
        />
     );
   });
@@ -50,6 +53,27 @@ describe("DateTimePickerMonths", function() {
        TestUtils.Simulate.click(month);
        expect(setViewMonthMock.mock.calls.length).toBe(1);
       });
+
+     describe("when the date picker mode is set to month picker", function() {
+       it("calls setSelectedMonth when clicking a month", function() {
+         months = TestUtils.renderIntoDocument(
+           <DateTimePickerMonths
+             addYear={addYearMock}
+             selectedDate={moment()}
+             setViewMonth={setViewMonthMock}
+             showYears={showYearsMock}
+             subtractYear={subtractYearMock}
+             viewDate={moment()}
+             setSelectedMonth={setSelectedMonthMock}
+             mode={"month"}
+           />
+         );
+
+         const month = TestUtils.findRenderedDOMComponentWithClass(months, "active");
+         TestUtils.Simulate.click(month);
+         expect(setSelectedMonthMock.mock.calls.length).toBe(1);
+        });
+     });
   });
 
   describe("UI", function() {
@@ -77,6 +101,8 @@ describe("DateTimePickerMonths", function() {
           showYears={showYearsMock}
           subtractYear={subtractYearMock}
           viewDate={moment().add(2, "year")}
+          setSelectedMonth={setSelectedMonthMock}
+          mode={"date"}
          />
       );
       const active = TestUtils.scryRenderedDOMComponentsWithClass(months, "active");


### PR DESCRIPTION
Fixes #119.

My approach for this was not to give a preset day, but to set the existing `mode` prop to `month`, rather than `date` or `time`.

It will never modify the day portion of whatever was given for `dateTime`. I.e., by default the day will always be today's day of month, or if you initialise the component with `dateTime="2015-01-01"`, then the selected date will always be the first day of whatever month the user picks.
