### PR TITLE
Makes names of days in datepicker location aware

### DIFF
--- a/src/DateTimePickerDays.js
+++ b/src/DateTimePickerDays.js
@@ -69,6 +69,7 @@ export default class DateTimePickerDays extends Component {
   }
 
   render() {
+    var startOfWeek = moment().startOf('week');
     return (
     <div className="datepicker-days" style={{display: "block"}}>
         <table className="table-condensed">
@@ -82,19 +83,19 @@ export default class DateTimePickerDays extends Component {
             </tr>
 
             <tr>
-              <th className="dow">Su</th>
+              <th className="dow">{startOfWeek.format('dd')}</th>
 
-              <th className="dow">Mo</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
 
-              <th className="dow">Tu</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
 
-              <th className="dow">We</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
 
-              <th className="dow">Th</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
 
-              <th className="dow">Fr</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
 
-              <th className="dow">Sa</th>
+              <th className="dow">{startOfWeek.add(1, 'days').format('dd')}</th>
             </tr>
           </thead>
 
@@ -106,4 +107,3 @@ export default class DateTimePickerDays extends Component {
     );
   }
 }
-


### PR DESCRIPTION
Currently the names of days (above the date picker) are hard coded strings starting with "Su" (for Sunday). However this is not always correct, since start of the week is calculated based on `moment` and its locale.

**Example:**

When I change moment locale to for example Slovak:
```
import moment from 'moment';
import 'moment/locale/sk';
```

The week is supposed to start with *Monday* instead of *Sunday*. Weeks are correctly started with *Monday*, however day names at top (Su, Mo, Tu ...) are:

1) not translated
2) still start with *Sunday*

This pull request fixed both issues - it translates day names based on `moment` locale and also starts with correct day name.

**Screenshot:**
![screen shot 2016-05-11 at 14 39 02](https://cloud.githubusercontent.com/assets/1561771/15181207/26c403dc-1786-11e6-886b-1771c9f14236.png)
