### PR TITLE
Add moment object to dateTime PropTypes

### DIFF
--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -34,7 +34,8 @@ export default class DateTimeField extends Component {
   static propTypes = {
     dateTime: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.number
+      PropTypes.number,
+      PropTypes.instanceOf(moment)
     ]),
     onChange: PropTypes.func,
     format: PropTypes.string,


### PR DESCRIPTION
This eliminates the React warning when passing a moment object as the value of the `dateTime` prop.
