### PR TITLE
fixed time mode and included in label click error

### DIFF
--- a/src/DateTimePickerTime.js
+++ b/src/DateTimePickerTime.js
@@ -82,7 +82,7 @@ export default class DateTimePickerTime extends Component {
 
               <td className="separator"></td>
 
-              <td><button className="btn btn-primary" onClick={this.props.togglePeriod} type="button">{this.props.selectedDate.format("A")}</button></td>
+              <td><a className="btn btn-primary" onClick={this.props.togglePeriod}>{this.props.selectedDate.format("A")}</a></td>
             </tr>
 
             <tr>


### PR DESCRIPTION
  when use label include DateTimeField and use mode='time',
  inputFormat='HH:mm', click label or everywhere in the label will trigger the togglePeriod method and pop error.
  change the <button> to <a> can fix it.