### PR TITLE
Change default widget display style to none.

### DIFF
--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -58,7 +58,7 @@ export default class DateTimeField extends Component {
       inputFormat: this.resolvePropsInputFormat(),
       buttonIcon: this.props.mode === Constants.MODE_TIME ? "glyphicon-time" : "glyphicon-calendar",
       widgetStyle: {
-        display: "block",
+        display: "none",
         position: "absolute",
         left: -9999,
         zIndex: "9999 !important"


### PR DESCRIPTION
Widget element had display block style which caused reporting wrong
height and bugging for example bootstrap accordion. After showing
it and hiding again changes style to display none whats fixes bug.

I'll be glad if someone could help me find widget element in test since
i'm unable to do so.
